### PR TITLE
Fixed errors in tests

### DIFF
--- a/src/main/lombok/no/hvl/dat250/h2020/group5/entities/Poll.java
+++ b/src/main/lombok/no/hvl/dat250/h2020/group5/entities/Poll.java
@@ -36,7 +36,7 @@ public class Poll {
   @ToString.Exclude
   @EqualsAndHashCode.Exclude
   @JsonBackReference(value = "pollOwner")
-  @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "pollId")
   @Setter(AccessLevel.PRIVATE)
   private User pollOwner;
@@ -44,7 +44,7 @@ public class Poll {
   @ToString.Exclude
   @EqualsAndHashCode.Exclude
   @OneToMany(
-      fetch = FetchType.EAGER,
+      fetch = FetchType.LAZY,
       mappedBy = "poll",
       orphanRemoval = true,
       cascade = CascadeType.ALL)

--- a/src/test/java/no/hvl/dat250/h2020/group5/integrationtests/VoteControllerIT.java
+++ b/src/test/java/no/hvl/dat250/h2020/group5/integrationtests/VoteControllerIT.java
@@ -68,9 +68,10 @@ public class VoteControllerIT {
     for (Vote vote : voteRepository.findAll()) {
       vote.setVoterOnlyOnVoteSide(null);
       vote.setPollOnlyOnVoteSide(null);
-      voteRepository.delete(vote);
+      voteRepository.save(vote);
     }
 
+    voteRepository.deleteAll();
     pollRepository.deleteAll();
     userRepository.deleteAll();
     guestRepository.deleteAll();
@@ -87,8 +88,9 @@ public class VoteControllerIT {
     Vote savedVote = response.getBody();
     Assertions.assertNotNull(savedVote.getId());
     Assertions.assertEquals(AnswerType.YES, savedVote.getAnswer());
-    Assertions.assertEquals(1, pollRepository.findById(savedPoll.getId()).get().getVotes().size());
-    Assertions.assertEquals(1, userRepository.findById(savedUser.getId()).get().getVotes().size());
+    Assertions.assertEquals(1, voteRepository.count());
+    Assertions.assertEquals(savedPoll.getId(), voteRepository.findAll().get(0).getPoll().getId());
+    Assertions.assertEquals(savedUser.getId(), voteRepository.findAll().get(0).getVoter().getId());
   }
 
   @Test
@@ -102,8 +104,8 @@ public class VoteControllerIT {
     Vote savedVote = response.getBody();
     Assertions.assertNotNull(savedVote.getId());
     Assertions.assertEquals(AnswerType.NO, savedVote.getAnswer());
-    Assertions.assertEquals(1, pollRepository.findById(savedPoll.getId()).get().getVotes().size());
-    Assertions.assertEquals(
-        1, guestRepository.findById(savedGuest.getId()).get().getVotes().size());
+    Assertions.assertEquals(1, voteRepository.count());
+    Assertions.assertEquals(savedPoll.getId(), voteRepository.findAll().get(0).getPoll().getId());
+    Assertions.assertEquals(savedGuest.getId(), voteRepository.findAll().get(0).getVoter().getId());
   }
 }

--- a/src/test/java/no/hvl/dat250/h2020/group5/integrationtests/VoteControllerIT.java
+++ b/src/test/java/no/hvl/dat250/h2020/group5/integrationtests/VoteControllerIT.java
@@ -48,6 +48,17 @@ public class VoteControllerIT {
 
   @BeforeEach
   public void setUp() throws MalformedURLException {
+    for (Vote vote : voteRepository.findAll()) {
+      vote.setVoterOnlyOnVoteSide(null);
+      vote.setPollOnlyOnVoteSide(null);
+      voteRepository.save(vote);
+    }
+
+    voteRepository.deleteAll();
+    pollRepository.deleteAll();
+    userRepository.deleteAll();
+    guestRepository.deleteAll();
+
     this.base = new URL("http://localhost:" + port + "/votes");
 
     Poll poll =


### PR DESCRIPTION
Wanted to update the project so everything is as it should when we continue.

### **Updated**

- Removed cascade persist from poll to user. This feature is not necessary; you should not be able to change some user fields and then save poll to update the user.

- Set fetchtype on pollvotes to lazy. A poll should not necessarily fetch votes every time.

- **PollControllerIT**

   - Changed the order thing were saved in in the BeforeEach setup, as this caused several errors. Users should be saved first, before adding them to polls
   - Changed the responsetype on each request to match controller
   - Added additional assertions

- **PollRepositoryTest**

   - Found out that in these test it is possible to use methods like poll.getVotes(), even though votes are fetch lazily. Spring keeps the session open in these test, contrary to the IT tests.
   - Tests now uses the saved instance of a user or poll object.
   - Removed "shouldSaveUserWhenSavingPoll". This is a redundant feature, this should not be possible.
   - Added shouldDeleteReferenceToPollInUserWhenDeletingPollTest

- **PollControllerIT**
   - As mentioned in PollRepositoryTest, lazy initialised fields are not available in the IT test, I therefore removed these. All tests that require lazy fields to be fetched should be done in the repository tests
   - Added new assertions
   - new teardown method

- **GuestControllerIT**
   - Added code to ensure everything is deleted before each test
